### PR TITLE
Modify barring functionality and Solve PostProcessing issues

### DIFF
--- a/postprocessing.js
+++ b/postprocessing.js
@@ -353,9 +353,22 @@ function add_barlines(meiDoc, bar_by_note){
             // we are substitutin the original condition by checking that
             // the division by the barlength provides a number close to an integer
             if (Math.abs((accum / barLength_Sb) - Math.round(accum / barLength_Sb)) < 0.00001){
+                // Create dotted <barLine> element
                 var barline = meiDoc.createElementNS('http://www.music-encoding.org/ns/mei', 'barLine');
                 barline.setAttribute('form', 'dashed');
-                staff_layer.insertBefore(barline, noterest.nextSibling);
+                // Find the right position to add the new <barLine> element
+                // (before the next sibling of the current noterest, if this next sibling exists)
+                var nextsibling = noterest.nextElementSibling;
+                var parent = noterest.parentElement;
+                if (nextsibling == null){
+                    // if there is no following sibling (we are at the last child),
+                    // we append the barline at the end
+                    parent.appendChild(barline);
+                } else {
+                    // if there is a following sibling, we insert the barline before it
+                    parent.insertBefore(barline, nextsibling);
+                }
+                //noterest.parentElement.insertBefore(barline, noterest.nextElementSibling);
                 console.log('---- barline ----');
             }
         }

--- a/postprocessing.js
+++ b/postprocessing.js
@@ -365,8 +365,20 @@ function add_barlines(meiDoc, bar_by_note){
                     // we append the barline at the end
                     parent.appendChild(barline);
                 } else {
-                    // if there is a following sibling, we insert the barline before it
-                    parent.insertBefore(barline, nextsibling);
+                    // if there is a following sibling, we insert the barline before it (see 'else')
+                    // except if there is a dot, then we add it after the dot
+                    // (this is, before the next element, if there is one
+                    // or append it as a last child, if there is none)
+                    if (nextsibling.tagName == 'dot') {
+                        nextsibling = nextsibling.nextElementSibling;
+                        if (nextsibling == null){
+                            parent.appendChild(barline);
+                        } else {
+                            parent.insertBefore(barline, nextsibling);
+                        }
+                    } else {
+                        parent.insertBefore(barline, nextsibling);
+                    }
                 }
                 //noterest.parentElement.insertBefore(barline, noterest.nextElementSibling);
                 console.log('---- barline ----');

--- a/postprocessing.js
+++ b/postprocessing.js
@@ -370,7 +370,7 @@ function add_barlines(meiDoc, bar_by_note){
 const refine_score = (scoreDoc, switch_to_modern_clefs_flag, bar_by_note_value) => {
     if (switch_to_modern_clefs_flag) {
         mensural_to_modern_clefs(scoreDoc);
-    }
+    }// else, we stay with the original (mensural) clefs of the parts MEI file
     switch(bar_by_note_value) {
         case "None":
             break;

--- a/postprocessing.js
+++ b/postprocessing.js
@@ -411,10 +411,11 @@ const refine_score = (scoreDoc, switch_to_modern_clefs_flag, bar_by_note_value) 
             add_sb_value(scoreDoc);
             add_barlines(scoreDoc, bar_by_note_value);
             // Remove the 'sb_value' attribute for producing a valid file
-            for (var layer of scoreDoc.getElementsByTagName('layer')) {
-                for (var element of layer.children) {
-                    element.removeAttribute('sb_value');
-                }
+            for (var note of scoreDoc.getElementsByTagName('note')) {
+                note.removeAttribute('sb_value');
+            }
+            for (var rest of scoreDoc.getElementsByTagName('rest')) {
+                rest.removeAttribute('sb_value');
             }
     }
     return scoreDoc;


### PR DESCRIPTION
Modify barring functionality to work at different note levels, and correct issues when the barline falls within the `<corr>` element. Also, remove the `@sb_value` invalid attribute from all notes and rests, including the ones in `<corr>` or `<sic>` (which was an issue before).